### PR TITLE
[NCTO-147] Allow all origins in dev CORS + sync with frontend `./dev.sh`

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 set -e
 
-# Don't start if the image build fails.
 docker compose -f docker-compose.yml -f docker-compose.dev.yml build && \
 docker compose -f docker-compose.yml -f docker-compose.dev.yml up --watch backend

--- a/dev.sh
+++ b/dev.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+set -e
 
-docker compose -f docker-compose.yml -f docker-compose.dev.yml build
+# Don't start if the image build fails.
+docker compose -f docker-compose.yml -f docker-compose.dev.yml build && \
 docker compose -f docker-compose.yml -f docker-compose.dev.yml up --watch backend

--- a/src/main.ts
+++ b/src/main.ts
@@ -56,8 +56,7 @@ if (isProduction) {
   );
 
   app.enableCors({
-    // In dev the frontend may be reached via localhost or a LAN IP, so reflect any origin.
-    // `origin: true` echoes the request origin, which (unlike "*") works with credentials.
+    // `origin: true` reflects the request origin, which (unlike "*") works with credentials.
     origin: isProduction ? frontendUrl : true,
     credentials: true,
     methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],

--- a/src/main.ts
+++ b/src/main.ts
@@ -56,7 +56,6 @@ if (isProduction) {
   );
 
   app.enableCors({
-    // `origin: true` reflects the request origin, which (unlike "*") works with credentials.
     origin: isProduction ? frontendUrl : true,
     credentials: true,
     methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,7 +19,9 @@ import * as dotenv from "dotenv";
 import cookieParser from "cookie-parser";
 import { format } from "date-fns-tz";
 
-if (process.env["NODE_ENV"] === "production") {
+const isProduction = process.env["NODE_ENV"] === "production";
+
+if (isProduction) {
   dotenv.config({ path: ".env.production" });
 } else {
   dotenv.config();
@@ -54,7 +56,9 @@ if (process.env["NODE_ENV"] === "production") {
   );
 
   app.enableCors({
-    origin: frontendUrl,
+    // In dev the frontend may be reached via localhost or a LAN IP, so reflect any origin.
+    // `origin: true` echoes the request origin, which (unlike "*") works with credentials.
+    origin: isProduction ? frontendUrl : true,
     credentials: true,
     methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
     allowedHeaders: ["Content-Type", "Authorization"]


### PR DESCRIPTION
## Jira ticket
NCTO-147 (Phase 2 — frontend cleanup; backend-side support)

## What does your MR do ?
Two dev-only changes supporting the frontend NCTO-147 work (companion to Naucto/Frontend#82):

1. **Dev CORS allows all origins.** The dev frontend now resolves the backend as *same host as the page* + `:3000`, so it may be reached via `localhost` **or** a LAN IP; the previous fixed single-origin CORS (`origin: FRONTEND_URL`) rejected those.
   - Dev (`NODE_ENV !== "production"`): `origin: true` — reflects the request's Origin. Because the frontend sends credentials (`withCredentials: true`), a literal `*` is invalid; reflecting the origin is the credential-safe way to allow all.
   - Production: unchanged — CORS stays restricted to `FRONTEND_URL`.
2. **`dev.sh` fails fast.** Chain `build && up` (with `set -e`) so a failed image build doesn't leave the watcher running against a stale image — mirroring the frontend `dev.sh`.

## How to test it
- Dev CORS: start the backend (non-production `NODE_ENV`), open the frontend via `localhost:3001` and via the host's LAN IP — both reach the API without CORS errors. With `NODE_ENV=production`, other origins are still blocked.
- dev.sh: a failing `docker compose … build` now stops the script before `up`.
- :warning: Other workflows to start the backend/frontend are now defacto __**unsupported**__. If you have problems with the script, ping me on Discord, but don't try to workaround it yourself please.

## Screenshot
N/A

## Notes
- `src/main.ts`: one-line behavioural change (plus a shared `isProduction` const reused by the existing dotenv branch). `eslint src/main.ts` clean.
- Note: `npm run build` currently fails on pre-existing TypeScript errors in `src/routes/user/user.service.ts` (Prisma `description` field) unrelated to this change — flagging for visibility, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)