### PR TITLE
[NCTO-248] Slim the production Docker image (2.3GB -> 537MB)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,9 @@ README.md
 license.txt
 dist
 node_modules
+coverage
+generated_client
+test
+memories
+Session.vim
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,20 +15,43 @@ WORKDIR /app
 
 ENV DATABASE_URL="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}"
 
-COPY package.json ./
+COPY package.json package-lock.json ./
 COPY prisma.config.ts ./
 COPY prisma ./prisma
 
-RUN npm install
+# Full dependency set (build + dev tooling), shared by the dev and build stages.
+FROM base AS deps
+RUN npm ci
 RUN npx prisma generate
 
-FROM base AS dev
+FROM deps AS dev
 ENV PORT=${BACKEND_PORT}
 COPY . .
 CMD ["sh", "-c", "npx prisma migrate deploy && npm run start:dev"]
 
-FROM base AS prod
+FROM deps AS build
 COPY . .
 RUN npm run build
+
+# Migration runner: reuses the build stage (which has the Prisma CLI) to apply
+# pending migrations as a one-off step, decoupled from the runtime image.
+FROM build AS migrate
+CMD ["npx", "prisma", "migrate", "deploy"]
+
+# Slim production runtime: production dependencies only (no Prisma CLI, no dev
+# tooling), the generated Prisma client copied from the build stage, and the
+# compiled output -- no source or test assets. Migrations run via the `migrate`
+# stage above, not here.
+FROM base AS prod
 ENV PORT=${BACKEND_PORT}
-CMD ["sh", "-c", "npx prisma migrate deploy && npm run start:prod"]
+# Swagger UI is not served in production, so drop its bundled static assets.
+ENV ENABLE_SWAGGER=false
+# --omit=optional drops the Prisma CLI + TypeScript, which @prisma/client only
+# declares as optional peer deps (the runtime client needs neither).
+RUN npm ci --omit=dev --omit=optional \
+    && rm -rf node_modules/swagger-ui-dist \
+    && npm cache clean --force
+COPY --from=build /app/node_modules/.prisma ./node_modules/.prisma
+COPY --from=build /app/dist ./dist
+COPY config ./config
+CMD ["npm", "run", "start:prod"]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -11,6 +11,11 @@ services:
   backend:
     build:
       target: dev
+    # The dev image bundles the Prisma CLI and self-migrates on start (see the
+    # dev stage CMD), so the prod-only `migrate` service is not needed here.
+    depends_on: !override
+      db:
+        condition: service_healthy
     networks:
       - naucto-dev
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,27 @@ services:
     networks:
       - naucto
 
+  migrate:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: migrate
+      args:
+        - BACKEND_PORT=${BACKEND_PORT}
+        - POSTGRES_USER=${POSTGRES_USER}
+        - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+        - POSTGRES_DB=${POSTGRES_DB}
+        - POSTGRES_HOST=${POSTGRES_HOST}
+        - POSTGRES_PORT=${POSTGRES_PORT}
+    depends_on:
+      db:
+        condition: service_healthy
+    env_file:
+      - .env
+    restart: "no"
+    networks:
+      - naucto
+
   backend:
     build:
       context: .
@@ -36,6 +57,8 @@ services:
     depends_on:
       db:
         condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
     env_file:
       - .env
     ports:

--- a/src/main.ts
+++ b/src/main.ts
@@ -76,7 +76,11 @@ if (isProduction) {
     next();
   });
 
-  setupSwagger(app);
+  if (process.env["ENABLE_SWAGGER"] !== "false") {
+    setupSwagger(app);
+  } else {
+    logger.log("Swagger disabled (ENABLE_SWAGGER=false)");
+  }
 
   await app.init();
 


### PR DESCRIPTION
## Jira ticket
https://naucto.atlassian.net/browse/NCTO-248?atlOrigin=eyJpIjoiNzEwMzE4Y2E5MjFiNGQyMDk4NWQ5MGM5NzM0MzZmZDMiLCJwIjoiaiJ9

## What does your MR do ?
- Multi-stage Dockerfile: prod runs `npm ci --omit=dev --omit=optional` (the latter drops the Prisma CLI + TypeScript, which @prisma/client only declares as optional peer deps), copies the generated client and dist from the build stage, and no longer runs the CLI or carries dev tooling.
- Decouple migrations: a dedicated `migrate` stage/service applies `prisma migrate deploy` as a one-off before the backend starts, so the runtime image no longer needs the ~150MB Prisma CLI tooling. Dev keeps self-migrating via its CMD (depends_on overridden to db only).
- Disable Swagger in production (ENABLE_SWAGGER=false) and prune the bundled swagger-ui-dist static assets.
- Clean the npm cache in-layer and tidy .dockerignore.

## How to test it
- Launch the backend + frontend as usual and check if there are any regressions

## Screenshot
n/a

## Notes
n/a
