### PR TITLE
[BACK] [FIX] Make third-party OAuth providers optional

### DIFF
--- a/src/auth/providers/github-auth.service.spec.ts
+++ b/src/auth/providers/github-auth.service.spec.ts
@@ -1,0 +1,60 @@
+import { ServiceUnavailableException } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { GithubAuthService } from "./github-auth.service";
+
+function configWith(values: Record<string, string | undefined>): ConfigService {
+  return { get: (key: string) => values[key] } as unknown as ConfigService;
+}
+
+const FULL_CONFIG = {
+  GITHUB_CLIENT_ID: "client-id",
+  GITHUB_CLIENT_SECRET: "client-secret"
+};
+
+describe("GithubAuthService", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("disables itself (no throw) when configuration is missing", async () => {
+    const service = new GithubAuthService(configWith({}));
+
+    expect(service.isAvailable).toBe(false);
+    await expect(service.getUserFromCode("code")).rejects.toBeInstanceOf(
+      ServiceUnavailableException
+    );
+  });
+
+  it("is available when fully configured", () => {
+    expect(new GithubAuthService(configWith(FULL_CONFIG)).isAvailable).toBe(
+      true
+    );
+  });
+
+  it("returns the user payload on a successful code exchange", async () => {
+    const service = new GithubAuthService(configWith(FULL_CONFIG));
+
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ access_token: "at" })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          login: "ada",
+          name: "Ada",
+          email: "ada@example.com"
+        })
+      });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await service.getUserFromCode("code");
+
+    expect(result).toEqual({ email: "ada@example.com", name: "Ada" });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/auth/providers/github-auth.service.ts
+++ b/src/auth/providers/github-auth.service.ts
@@ -1,9 +1,4 @@
-import {
-  Injectable,
-  InternalServerErrorException,
-  Logger,
-  UnauthorizedException
-} from "@nestjs/common";
+import { Injectable, UnauthorizedException } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { OAuthUserPayload } from "../auth.types";
 import {
@@ -11,29 +6,30 @@ import {
   GithubTokenResponse,
   GithubUser
 } from "../dto/github-auth.dto";
-import { getExcerrMessage } from "../../util/errors";
+import { OAuthProviderService } from "./oauth-provider.base";
 
 @Injectable()
-export class GithubAuthService {
-  private readonly logger = new Logger(GithubAuthService.name);
-  private readonly clientId: string;
-  private readonly clientSecret: string;
+export class GithubAuthService extends OAuthProviderService {
+  private readonly clientId!: string;
+  private readonly clientSecret!: string;
 
   constructor(configService: ConfigService) {
-    const clientId = configService.get<string>("GITHUB_CLIENT_ID");
-    const clientSecret = configService.get<string>("GITHUB_CLIENT_SECRET");
+    super("GitHub");
 
-    if (!clientId || !clientSecret) {
-      throw new InternalServerErrorException(
-        "Missing GitHub OAuth configuration: GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET are required"
-      );
+    const config = this.loadConfig(configService, [
+      "GITHUB_CLIENT_ID",
+      "GITHUB_CLIENT_SECRET"
+    ]);
+
+    if (config) {
+      this.clientId = config["GITHUB_CLIENT_ID"]!;
+      this.clientSecret = config["GITHUB_CLIENT_SECRET"]!;
     }
-
-    this.clientId = clientId;
-    this.clientSecret = clientSecret;
   }
 
   async getUserFromCode(code: string): Promise<OAuthUserPayload> {
+    this.ensureAvailable();
+
     const accessToken = await this.exchangeCodeForToken(code);
     const githubUser = await this.fetchUser(accessToken);
     const email =
@@ -46,29 +42,22 @@ export class GithubAuthService {
   }
 
   private async exchangeCodeForToken(code: string): Promise<string> {
-    let response: Response;
-    try {
-      response = await fetch(
-        "https://github.com/login/oauth/access_token",
-        {
-          method: "POST",
-          headers: {
-            Accept: "application/json",
-            "Content-Type": "application/json"
-          },
-          body: JSON.stringify({
-            client_id: this.clientId,
-            client_secret: this.clientSecret,
-            code
-          })
-        }
-      );
-    } catch (err) {
-      this.logger.error(`GitHub token endpoint unreachable: ${getExcerrMessage(err)}`);
-      throw new UnauthorizedException("GitHub authentication service unavailable");
-    }
-
-    const data = (await response.json()) as GithubTokenResponse;
+    const data = await this.fetchJson<GithubTokenResponse>(
+      "https://github.com/login/oauth/access_token",
+      {
+        method: "POST",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({
+          client_id: this.clientId,
+          client_secret: this.clientSecret,
+          code
+        })
+      },
+      { unreachable: "GitHub authentication service unavailable" }
+    );
 
     if (data.error || !data.access_token) {
       this.logger.warn(
@@ -81,45 +70,36 @@ export class GithubAuthService {
   }
 
   private async fetchUser(accessToken: string): Promise<GithubUser> {
-    let response: Response;
-    try {
-      response = await fetch("https://api.github.com/user", {
+    return this.fetchJson<GithubUser>(
+      "https://api.github.com/user",
+      {
         headers: {
           Authorization: `Bearer ${accessToken}`,
           "User-Agent": "NestJS-Backend"
         }
-      });
-    } catch (err) {
-      this.logger.error(`GitHub user endpoint unreachable: ${getExcerrMessage(err)}`);
-      throw new UnauthorizedException("GitHub authentication service unavailable");
-    }
-
-    if (!response.ok) {
-      throw new UnauthorizedException("Failed to fetch GitHub user info");
-    }
-
-    return response.json() as Promise<GithubUser>;
+      },
+      {
+        unreachable: "GitHub authentication service unavailable",
+        badResponse: "Failed to fetch GitHub user info"
+      }
+    );
   }
 
   private async fetchPrimaryEmail(accessToken: string): Promise<string> {
-    let response: Response;
-    try {
-      response = await fetch("https://api.github.com/user/emails", {
+    const emails = await this.fetchJson<GithubEmail[]>(
+      "https://api.github.com/user/emails",
+      {
         headers: {
           Authorization: `Bearer ${accessToken}`,
           "User-Agent": "NestJS-Backend"
         }
-      });
-    } catch (err) {
-      this.logger.error(`GitHub emails endpoint unreachable: ${getExcerrMessage(err)}`);
-      throw new UnauthorizedException("GitHub authentication service unavailable");
-    }
+      },
+      {
+        unreachable: "GitHub authentication service unavailable",
+        badResponse: "Failed to fetch GitHub user emails"
+      }
+    );
 
-    if (!response.ok) {
-      throw new UnauthorizedException("Failed to fetch GitHub user emails");
-    }
-
-    const emails = (await response.json()) as GithubEmail[];
     const primary = emails.find((e) => e.primary && e.verified);
 
     if (!primary) {

--- a/src/auth/providers/google-auth.service.spec.ts
+++ b/src/auth/providers/google-auth.service.spec.ts
@@ -1,0 +1,62 @@
+import { ServiceUnavailableException } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { GoogleAuthService } from "./google-auth.service";
+
+function configWith(values: Record<string, string | undefined>): ConfigService {
+  return { get: (key: string) => values[key] } as unknown as ConfigService;
+}
+
+const FULL_CONFIG = {
+  GOOGLE_CLIENT_ID: "client-id",
+  GOOGLE_CLIENT_SECRET: "client-secret",
+  GOOGLE_REDIRECT_URI: "https://app.example/callback"
+};
+
+describe("GoogleAuthService", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("disables itself (no throw) when configuration is missing", async () => {
+    const service = new GoogleAuthService(configWith({}));
+
+    expect(service.isAvailable).toBe(false);
+    await expect(
+      service.getUserFromCode("code", "verifier")
+    ).rejects.toBeInstanceOf(ServiceUnavailableException);
+  });
+
+  it("is available when fully configured", () => {
+    expect(new GoogleAuthService(configWith(FULL_CONFIG)).isAvailable).toBe(
+      true
+    );
+  });
+
+  it("returns the user payload on a successful code exchange", async () => {
+    const service = new GoogleAuthService(configWith(FULL_CONFIG));
+
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ access_token: "at" })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          email: "ada@example.com",
+          email_verified: true,
+          sub: "1",
+          name: "Ada"
+        })
+      });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await service.getUserFromCode("code", "verifier");
+
+    expect(result).toEqual({ email: "ada@example.com", name: "Ada" });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/auth/providers/google-auth.service.ts
+++ b/src/auth/providers/google-auth.service.ts
@@ -1,44 +1,40 @@
-import {
-  Injectable,
-  InternalServerErrorException,
-  Logger,
-  UnauthorizedException
-} from "@nestjs/common";
+import { Injectable, UnauthorizedException } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { OAuthUserPayload } from "../auth.types";
-import {
-  GoogleTokenResponse,
-  GoogleUserInfo
-} from "../dto/google-auth.dto";
-import { getExcerrMessage } from "../../util/errors";
+import { GoogleTokenResponse, GoogleUserInfo } from "../dto/google-auth.dto";
+import { OAuthProviderService } from "./oauth-provider.base";
 
 @Injectable()
-export class GoogleAuthService {
-  private readonly logger = new Logger(GoogleAuthService.name);
-  private readonly clientId: string;
-  private readonly clientSecret: string;
-  private readonly redirectUri: string;
+export class GoogleAuthService extends OAuthProviderService {
+  private readonly clientId!: string;
+  private readonly clientSecret!: string;
+  private readonly redirectUri!: string;
 
   constructor(configService: ConfigService) {
-    const clientId = configService.get<string>("GOOGLE_CLIENT_ID");
-    const clientSecret = configService.get<string>("GOOGLE_CLIENT_SECRET");
-    const redirectUri = configService.get<string>("GOOGLE_REDIRECT_URI");
+    super("Google");
 
-    if (!clientId || !clientSecret || !redirectUri) {
-      throw new InternalServerErrorException(
-        "Missing Google OAuth configuration: GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET and GOOGLE_REDIRECT_URI are required"
-      );
+    const config = this.loadConfig(configService, [
+      "GOOGLE_CLIENT_ID",
+      "GOOGLE_CLIENT_SECRET",
+      "GOOGLE_REDIRECT_URI"
+    ]);
+
+    if (config) {
+      this.clientId = config["GOOGLE_CLIENT_ID"]!;
+      this.clientSecret = config["GOOGLE_CLIENT_SECRET"]!;
+      this.redirectUri = config["GOOGLE_REDIRECT_URI"]!;
     }
-
-    this.clientId = clientId;
-    this.clientSecret = clientSecret;
-    this.redirectUri = redirectUri;
   }
 
-  async getUserFromCode(code: string, codeVerifier: string): Promise<OAuthUserPayload> {
-    let tokenRes: Response;
-    try {
-      tokenRes = await fetch("https://oauth2.googleapis.com/token", {
+  async getUserFromCode(
+    code: string,
+    codeVerifier: string
+  ): Promise<OAuthUserPayload> {
+    this.ensureAvailable();
+
+    const tokens = await this.fetchJson<GoogleTokenResponse>(
+      "https://oauth2.googleapis.com/token",
+      {
         method: "POST",
         headers: { "Content-Type": "application/x-www-form-urlencoded" },
         body: new URLSearchParams({
@@ -47,39 +43,35 @@ export class GoogleAuthService {
           code,
           code_verifier: codeVerifier,
           redirect_uri: this.redirectUri,
-          grant_type: "authorization_code",
-        }),
-      });
-    } catch (err) {
-      this.logger.error(`Google token endpoint unreachable: ${getExcerrMessage(err)}`);
-      throw new UnauthorizedException("Google authentication service unavailable");
-    }
+          grant_type: "authorization_code"
+        })
+      },
+      { unreachable: "Google authentication service unavailable" }
+    );
 
-    const tokens = await tokenRes.json() as GoogleTokenResponse;
     if (tokens.error || !tokens.access_token) {
-      this.logger.warn(`Google code exchange failed: ${tokens.error_description ?? tokens.error}`);
-      throw new UnauthorizedException("Failed to exchange Google authorization code");
+      this.logger.warn(
+        `Google code exchange failed: ${tokens.error_description ?? tokens.error}`
+      );
+      throw new UnauthorizedException(
+        "Failed to exchange Google authorization code"
+      );
     }
 
     return this.verifyToken(tokens.access_token);
   }
 
   async verifyToken(token: string): Promise<OAuthUserPayload> {
-    let response: Response;
-    try {
-      response = await fetch("https://www.googleapis.com/oauth2/v3/userinfo", {
-        headers: { Authorization: `Bearer ${token}` }
-      });
-    } catch (error) {
-      this.logger.warn(`Google userinfo endpoint unreachable: ${getExcerrMessage(error)}`);
-      throw new UnauthorizedException("Invalid Google token");
-    }
+    this.ensureAvailable();
 
-    if (!response.ok) {
-      throw new UnauthorizedException("Invalid Google token");
-    }
-
-    const userInfo = await response.json() as GoogleUserInfo;
+    const userInfo = await this.fetchJson<GoogleUserInfo>(
+      "https://www.googleapis.com/oauth2/v3/userinfo",
+      { headers: { Authorization: `Bearer ${token}` } },
+      {
+        unreachable: "Invalid Google token",
+        badResponse: "Invalid Google token"
+      }
+    );
 
     if (!userInfo.email_verified) {
       throw new UnauthorizedException("Google email not verified");

--- a/src/auth/providers/microsoft-auth.service.spec.ts
+++ b/src/auth/providers/microsoft-auth.service.spec.ts
@@ -1,0 +1,29 @@
+import { ServiceUnavailableException } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { MicrosoftAuthService } from "./microsoft-auth.service";
+
+function configWith(values: Record<string, string | undefined>): ConfigService {
+  return { get: (key: string) => values[key] } as unknown as ConfigService;
+}
+
+const FULL_CONFIG = {
+  MICROSOFT_CLIENT_ID: "client-id",
+  MICROSOFT_TENANT_ID: "tenant-id"
+};
+
+describe("MicrosoftAuthService", () => {
+  it("disables itself (no throw) when configuration is missing", async () => {
+    const service = new MicrosoftAuthService(configWith({}));
+
+    expect(service.isAvailable).toBe(false);
+    await expect(service.verifyToken("id-token")).rejects.toBeInstanceOf(
+      ServiceUnavailableException
+    );
+  });
+
+  it("is available when fully configured", () => {
+    expect(new MicrosoftAuthService(configWith(FULL_CONFIG)).isAvailable).toBe(
+      true
+    );
+  });
+});

--- a/src/auth/providers/microsoft-auth.service.ts
+++ b/src/auth/providers/microsoft-auth.service.ts
@@ -1,36 +1,39 @@
-import { Injectable, InternalServerErrorException, UnauthorizedException } from "@nestjs/common";
+import { Injectable, UnauthorizedException } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { OAuthUserPayload } from "../auth.types";
 import * as jwt from "jsonwebtoken";
 import jwksRsa from "jwks-rsa";
+import { OAuthProviderService } from "./oauth-provider.base";
 
 @Injectable()
-export class MicrosoftAuthService {
-  private readonly clientId: string;
-  private readonly tenantId: string;
-  private readonly jwksClient: jwksRsa.JwksClient;
+export class MicrosoftAuthService extends OAuthProviderService {
+  private readonly clientId!: string;
+  private readonly tenantId!: string;
+  private readonly jwksClient!: jwksRsa.JwksClient;
 
   constructor(configService: ConfigService) {
-    const clientId = configService.get<string>("MICROSOFT_CLIENT_ID");
-    const tenantId = configService.get<string>("MICROSOFT_TENANT_ID");
+    super("Microsoft");
 
-    if (!clientId || !tenantId) {
-      throw new InternalServerErrorException(
-        "Missing Microsoft OAuth configuration: MICROSOFT_CLIENT_ID and MICROSOFT_TENANT_ID are required"
-      );
+    const config = this.loadConfig(configService, [
+      "MICROSOFT_CLIENT_ID",
+      "MICROSOFT_TENANT_ID"
+    ]);
+
+    if (config) {
+      this.clientId = config["MICROSOFT_CLIENT_ID"]!;
+      this.tenantId = config["MICROSOFT_TENANT_ID"]!;
+      this.jwksClient = jwksRsa({
+        jwksUri: `https://login.microsoftonline.com/${this.tenantId}/discovery/v2.0/keys`,
+        cache: true,
+        cacheMaxAge: 10 * 60 * 1000,
+        rateLimit: true
+      });
     }
-
-    this.clientId = clientId;
-    this.tenantId = tenantId;
-    this.jwksClient = jwksRsa({
-      jwksUri: `https://login.microsoftonline.com/${tenantId}/discovery/v2.0/keys`,
-      cache: true,
-      cacheMaxAge: 10 * 60 * 1000,
-      rateLimit: true,
-    });
   }
 
   async verifyToken(idToken: string): Promise<OAuthUserPayload> {
+    this.ensureAvailable();
+
     const decoded = jwt.decode(idToken, { complete: true });
 
     if (!decoded || typeof decoded.payload === "string") {
@@ -50,7 +53,7 @@ export class MicrosoftAuthService {
       payload = jwt.verify(idToken, publicKey, {
         algorithms: ["RS256"],
         audience: this.clientId,
-        issuer: `https://login.microsoftonline.com/${this.tenantId}/v2.0`,
+        issuer: `https://login.microsoftonline.com/${this.tenantId}/v2.0`
       }) as jwt.JwtPayload;
     } catch {
       throw new UnauthorizedException("Microsoft token signature invalid");

--- a/src/auth/providers/oauth-provider.base.ts
+++ b/src/auth/providers/oauth-provider.base.ts
@@ -1,0 +1,85 @@
+import {
+  Logger,
+  ServiceUnavailableException,
+  UnauthorizedException
+} from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { getExcerrMessage } from "../../util/errors";
+
+// Shared base for third-party OAuth providers. Missing configuration disables a
+// provider (logged warning) instead of crashing boot, so providers are optional
+// per environment. Also centralizes the repeated fetch/error plumbing.
+export abstract class OAuthProviderService {
+  protected readonly logger: Logger;
+  private _available = false;
+
+  constructor(protected readonly providerName: string) {
+    this.logger = new Logger(`${providerName}AuthService`);
+  }
+
+  get isAvailable(): boolean {
+    return this._available;
+  }
+
+  // Reads every required var; on any miss, warns and disables the provider
+  // (returns null) rather than throwing, so the app can still boot.
+  protected loadConfig(
+    configService: ConfigService,
+    vars: string[]
+  ): Record<string, string> | null {
+    const values: Record<string, string> = {};
+    const missing: string[] = [];
+
+    for (const name of vars) {
+      const value = configService.get<string>(name);
+      if (value) {
+        values[name] = value;
+      } else {
+        missing.push(name);
+      }
+    }
+
+    if (missing.length > 0) {
+      this.logger.warn(
+        `${this.providerName} OAuth disabled: missing ${missing.join(", ")}`
+      );
+      this._available = false;
+      return null;
+    }
+
+    this._available = true;
+    return values;
+  }
+
+  // Guards a public method so a disabled provider fails cleanly (503) instead of
+  // dereferencing absent config.
+  protected ensureAvailable(): void {
+    if (!this._available) {
+      throw new ServiceUnavailableException(
+        `${this.providerName} authentication is not configured`
+      );
+    }
+  }
+
+  // Wraps fetch + JSON parsing with consistent error handling. Domain checks on
+  // the parsed body stay with the caller.
+  protected async fetchJson<T>(
+    url: string,
+    init: RequestInit,
+    msgs: { unreachable: string; badResponse?: string }
+  ): Promise<T> {
+    let response: Response;
+    try {
+      response = await fetch(url, init);
+    } catch (err) {
+      this.logger.error(`${url} unreachable: ${getExcerrMessage(err)}`);
+      throw new UnauthorizedException(msgs.unreachable);
+    }
+
+    if (msgs.badResponse && !response.ok) {
+      throw new UnauthorizedException(msgs.badResponse);
+    }
+
+    return (await response.json()) as T;
+  }
+}


### PR DESCRIPTION
## Problem

Booting the backend crashes if Google/GitHub/Microsoft OAuth env vars are unset — each provider validates config in its **constructor** and throws `InternalServerErrorException`, and all three are eagerly instantiated in `AuthModule`:

```
ERROR [ExceptionHandler] InternalServerErrorException: Missing Google OAuth configuration...
    at new GoogleAuthService (src/auth/providers/google-auth.service.ts:28:13)
```

Third-party login should be **optional**, especially in dev.

## Change

- Each provider now **self-disables with a logged warning** when its config is missing, instead of throwing at construction — so the app boots with any subset of providers configured. Availability is per-provider (an unconfigured Google doesn't disable GitHub).
- A disabled provider's endpoint returns **503 Service Unavailable** (clean error) instead of crashing/500-ing.
- Code-smell pass: the three providers now extend a shared `OAuthProviderService` base — one config-loading/availability path (`loadConfig`/`ensureAvailable`) and a shared `fetchJson` helper replace the copy-pasted constructor validation, `fetch`/try-catch/`response.ok` plumbing, and logger setup.

Mirrors the existing `WebRTCService` pattern (warn + guard at use-time rather than throw at construction). No changes to `AuthModule`/`AuthService`/`AuthController` logic — the 503 propagates through the delegating `loginWith*` methods.

## Tests

- New `{google,github,microsoft}-auth.service.spec.ts`: missing config → constructor doesn't throw, `isAvailable === false`, method rejects with `ServiceUnavailableException`; full config → `isAvailable === true` (+ happy-path code exchange for Google/GitHub with a mocked `fetch`).
- Full suite green: 16 suites / 99 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)